### PR TITLE
use AdamW from torch.optim instead

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ datasets
 tqdm
 scikit-learn
 pandas
+gensim

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
         "tqdm",
         "scikit-learn",
         "pandas",
+        "gensim",
     ],
     packages=find_packages(exclude=['tests']),
     package_dir={'text2vec': 'text2vec'},

--- a/text2vec/bertmatching_model.py
+++ b/text2vec/bertmatching_model.py
@@ -11,10 +11,11 @@ import pandas as pd
 import torch
 from loguru import logger
 from torch import nn
+from torch.optim import AdamW
 from torch.utils.data import DataLoader, Dataset, DistributedSampler
 from tqdm import tqdm, trange
 from transformers import BertForSequenceClassification, BertTokenizer
-from transformers.optimization import AdamW, get_linear_schedule_with_warmup
+from transformers.optimization import get_linear_schedule_with_warmup
 
 from text2vec.bertmatching_dataset import (
     BertMatchingTestDataset,

--- a/text2vec/bge_model.py
+++ b/text2vec/bge_model.py
@@ -13,9 +13,10 @@ import pandas as pd
 import torch
 from loguru import logger
 from torch import nn
+from torch.optim import AdamW
 from torch.utils.data import DataLoader, Dataset, DistributedSampler
 from tqdm import tqdm, trange
-from transformers.optimization import AdamW, get_linear_schedule_with_warmup
+from transformers.optimization import get_linear_schedule_with_warmup
 
 from text2vec.bge_dataset import BgeTrainDataset
 from text2vec.sentence_model import SentenceModel

--- a/text2vec/cosent_model.py
+++ b/text2vec/cosent_model.py
@@ -11,9 +11,10 @@ import pandas as pd
 import torch
 from loguru import logger
 from torch import nn
+from torch.optim import AdamW
 from torch.utils.data import DataLoader, Dataset, DistributedSampler
 from tqdm import tqdm, trange
-from transformers.optimization import AdamW, get_linear_schedule_with_warmup
+from transformers.optimization import get_linear_schedule_with_warmup
 
 from text2vec.cosent_dataset import CosentTrainDataset, load_cosent_train_data, HFCosentTrainDataset
 from text2vec.sentence_model import SentenceModel

--- a/text2vec/sentencebert_model.py
+++ b/text2vec/sentencebert_model.py
@@ -11,9 +11,10 @@ import pandas as pd
 import torch
 from loguru import logger
 from torch import nn
+from torch.optim import AdamW
 from torch.utils.data import DataLoader, Dataset, DistributedSampler
 from tqdm import tqdm, trange
-from transformers.optimization import AdamW, get_linear_schedule_with_warmup
+from transformers.optimization import get_linear_schedule_with_warmup
 
 from text2vec.sentence_model import SentenceModel
 from text2vec.text_matching_dataset import (


### PR DESCRIPTION
text2vec 与新版本的 transformers 库不兼容（>=4.50.0），原因是 AdamW 被移除了，导致 import error。详情可见 https://github.com/huggingface/transformers/commit/9be4728af8bec48073ae841881d7f4e2ac3521d1